### PR TITLE
change number of gene, delete overlap cell content

### DIFF
--- a/content/40.common-challenges.md
+++ b/content/40.common-challenges.md
@@ -10,7 +10,7 @@ The choice of methods mostly relied on the biological question to address: data 
 
 ### Common challenge 1: Dependence on pre-processing method and/or variable selection
 
-Pre-processing steps strongly affect downstream analyses. Our participants thoroughly assessed the effect of normalization and data transformation (e.g. spatial transcriptomics, Figure {@fig:spatial}A), as well as preliminary feature selection (mostly on based on highly variable genes) or feature summarization (scNMT-seq study). Ease of comparisons between analyses was facilitated by providing processed input data (see [software](#software-section) section), which still encountered reproducibility issues between the original published study and the new analyses. For example, in the spatial transcriptomics study, 19 genes were selected in [COullomb vignette to ref] (*in scRNA-seq? or seqFISH?*) whereas the original paper selected 47 genes based on the same feature selection process [@doi:10.1038/nbt.4260]. No consensus was reached across participants’ analyses regarding the best way to process such emerging data, as those would require extensive benchmark, ground truth, or established biological results are yet available, which we discuss in [benchmarking](#benchmarking-section). 
+Pre-processing steps strongly affect downstream analyses. Our participants thoroughly assessed the effect of normalization and data transformation (e.g. spatial transcriptomics, Figure {@fig:spatial}A), as well as preliminary feature selection (mostly on based on highly variable genes) or feature summarization (scNMT-seq study). Ease of comparisons between analyses was facilitated by providing processed input data (see [software](#software-section) section), which still encountered reproducibility issues between the original published study and the new analyses. For example, in the spatial transcriptomics study, 19 genes were selected in [Coullomb vignette to ref] (*in scRNA-seq? or seqFISH?*) whereas the original paper selected 43 genes based on the same feature selection process [@doi:10.1038/nbt.4260]. No consensus was reached across participants’ analyses regarding the best way to process such emerging data, as those would require extensive benchmark, ground truth, or established biological results are yet available, which we discuss in [benchmarking](#benchmarking-section). 
 
 ### Common challenge 2: Managing differences in scale and size across datasets
 
@@ -119,7 +119,7 @@ Caption figure: **A.** Overlap of features (genes) but not cells (e.g. spatial t
     </tr>
     <tr>
       <td><b>No cell overlap</b><br> (complete feature overlap) </td>
-      <td>Averaging nearest neighbors in latent space to impute unmeasured expression values (Coullomb)</td>
+      <td></td>
       <td>Transfer cell type label with Random Forest (Hsu)</td>
       <td>LIGER [@doi:10.1101/459891] (Welch)</td>
     </tr>


### PR DESCRIPTION
change 47 genes to 43 in the original paper of seqFISH  
delete content in one cell about overlapping data and Coullomb's method, I've never imputed any data :smile: